### PR TITLE
Refactor/add core primitive conservation conversion implemenations

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,33 @@ References:
 - Jiang, G. S., & Shu, C. W. (1996). Efficient implementation of weighted ENO schemes. Journal of Computational Physics, 126(1), 202-228.
 - Shu, C. W. (1998). Essentially non-oscillatory and weighted essentially non-oscillatory schemes for hyperbolic conservation laws. In Advanced Numerical Approximation of Nonlinear Hyperbolic Equations (pp. 325-432). Springer.
 
+### Code architecture
+
+The library is built around a parent module, `fluid_forge`, that declares the public interface for every solver. Each scheme lives in its own **submodule** so that a single source file maps cleanly to the part of the algorithm that corresponds to its source paper:
+
+| File | Contains |
+|------|----------|
+| `src/fluid_forge.f90` | Parent module: public interface declarations (`fct`, `fct_2d`, `lax_wendroff`, `lax_friedrichs`, `roe`, `weno3`, `weno5`) |
+| `src/euler_core.f90` | **Shared physics for the 1D Euler solvers** (see below) |
+| `src/lax_wendroff_solver.f90` | Lax-Wendroff (Richtmyer two-step) submodule |
+| `src/lax_friedrichs_solver.f90` | Lax-Friedrichs submodule |
+| `src/roe_solver.f90` | Roe approximate Riemann solver + Roe-average eigendecomposition |
+| `src/weno3_solver.f90` | WENO3 reconstruction submodule |
+| `src/weno5_solver.f90` | WENO5 reconstruction submodule |
+| `src/fct_solver.f90`, `src/fct_2d_solver.f90` | 1D and 2D flux-corrected transport |
+| `src/fluid_1d_models.f90`, `src/fluid_2d_models.f90` | Scenario drivers that set up each test case and write the CSV output |
+
+#### Shared Euler physics (`euler_core`)
+
+Every finite-volume scheme for the Euler equations advances the same conserved state and uses the same physical flux; only the *numerical* interface flux F_{i+1/2} differs between schemes. `euler_core` centralises the parts that are common to all of them:
+
+- `gamma_g` — the single canonical ratio of specific heats (γ = 1.4) used by every Euler solver.
+- `prim_to_cons_flux(rho, u, p, u_cons, f_phys)` — primitives → conserved vector `U = (ρ, ρu, E)` **and** physical flux `F(U) = (ρu, ρu² + p, u(E + p))`, computed together to share the energy term.
+- `flux_from_cons(u_cons)` — physical flux evaluated directly from a conserved vector, for predictor-corrector schemes (e.g. Lax-Wendroff) whose intermediate state is conserved rather than primitive.
+- `cons_to_prim(u_cons, rho, u, p)` — conserved vector → primitives.
+
+The `lax_wendroff`, `roe`, `weno3`, and `weno5` submodules all `use euler_core` for these operations, so the equation of state lives in exactly one place. Each solver's file is left focused on the numerical flux that maps to its source paper — the Roe-average eigenstructure, the WENO reconstruction weights, and so on.
+
 ### Running the code
 
 Numerical methods are written in Fortran and plotting routines are implemented in Python's Matplotlib library.  Running the fortran is easiest by using [fpm](https://fpm.fortran-lang.org/) and running:

--- a/src/euler_core.f90
+++ b/src/euler_core.f90
@@ -1,0 +1,70 @@
+module euler_core
+  !> Shared physics for the 1D Euler solvers.
+  !>
+  !> Every finite-volume scheme in this library advances the same
+  !> conserved state and uses the same physical flux; only the *numerical*
+  !> interface flux differs between schemes. Centralising the equation of
+  !> state, the conserved vector
+  !>
+  !>     U = (rho, rho*u, E),     E = p/(gamma - 1) + 1/2 rho u^2
+  !>
+  !> and the physical flux
+  !>
+  !>     F(U) = (rho*u, rho*u^2 + p, u(E + p))
+  !>
+  !> in one place keeps each solver's file focused on the part that maps
+  !> to its source paper: the numerical flux F_{i+1/2}.
+  use iso_fortran_env, only: real64
+  implicit none
+  private
+
+  public :: gamma_g, prim_to_cons_flux, flux_from_cons, cons_to_prim
+
+  !> Ratio of specific heats (ideal gas). Single canonical value for all
+  !> solvers.
+  real(real64), parameter :: gamma_g = 1.4_real64
+
+  contains
+
+    !> Primitive (rho, u, p) at one cell -> conserved U = (rho, rho*u, E)
+    !> and physical flux F(U), computed together to share the energy term.
+    pure subroutine prim_to_cons_flux(rho, u, p, u_cons, f_phys)
+      real(real64), intent(in)  :: rho, u, p
+      real(real64), intent(out) :: u_cons(3), f_phys(3)
+
+      u_cons(1) = rho
+      u_cons(2) = rho * u
+      u_cons(3) = p / (gamma_g - 1.0_real64) + 0.5_real64 * rho * u**2
+
+      f_phys(1) = u_cons(2)
+      f_phys(2) = u_cons(2) * u + p
+      f_phys(3) = u * (u_cons(3) + p)
+    end subroutine prim_to_cons_flux
+
+    !> Physical flux F(U) evaluated directly from a conserved vector.
+    !> Needed by predictor-corrector schemes (e.g. Lax-Wendroff) whose
+    !> intermediate state is conserved rather than primitive.
+    pure function flux_from_cons(u_cons) result(f_phys)
+      real(real64), intent(in) :: u_cons(3)
+      real(real64) :: f_phys(3)
+      real(real64) :: u, p
+
+      u = u_cons(2) / u_cons(1)
+      p = (gamma_g - 1.0_real64) * (u_cons(3) - 0.5_real64 * u_cons(2)**2 / u_cons(1))
+
+      f_phys(1) = u_cons(2)
+      f_phys(2) = u_cons(2) * u + p
+      f_phys(3) = u * (u_cons(3) + p)
+    end function flux_from_cons
+
+    !> Conserved U = (rho, rho*u, E) -> primitives (rho, u, p).
+    pure subroutine cons_to_prim(u_cons, rho, u, p)
+      real(real64), intent(in)  :: u_cons(3)
+      real(real64), intent(out) :: rho, u, p
+
+      rho = u_cons(1)
+      u   = u_cons(2) / u_cons(1)
+      p   = (gamma_g - 1.0_real64) * (u_cons(3) - 0.5_real64 * u_cons(2)**2 / u_cons(1))
+    end subroutine cons_to_prim
+
+end module euler_core

--- a/src/lax_wendroff_solver.f90
+++ b/src/lax_wendroff_solver.f90
@@ -1,5 +1,6 @@
 submodule (fluid_forge) lax_wendroff_impl
   use iso_fortran_env, only: real64, int32
+  use euler_core, only: prim_to_cons_flux, flux_from_cons, cons_to_prim
   implicit none
 
   contains
@@ -37,51 +38,24 @@ submodule (fluid_forge) lax_wendroff_impl
     !> @param [in]    dt     Time step size
     !> @param [in]    dx     Grid spacing
     module procedure lax_wendroff
-      real(real64), parameter :: gamma = 1.4
       integer(int32) :: i
-      real(real64) :: eng, prsh, flux(9), W(9), uph(3), umh(3), uve(3)
+      real(real64) :: flux(9), W(9), uph(3), umh(3), uve(3), fph(3), fmh(3)
 
       do i = 3, nx - 2
-      ! conserved quantities
-      W(1) = rho(i-1)
-      W(2) = rho(i-1)*vel(i-1)
-      W(3) = rho(i-1)*((prs(i-1)/((gamma - 1.0)*rho(i-1))) + 0.5*vel(i-1)**2)
-      W(4) = rho(i)
-      W(5) = rho(i)*vel(i)
-      W(6) = rho(i)*((prs(i)/((gamma - 1.0)*rho(i))) + 0.5*vel(i)**2)
-      W(7) = rho(i+1)
-      W(8) = rho(i+1)*vel(i+1)
-      W(9) = rho(i+1)*((prs(i+1)/((gamma - 1.0)*rho(i+1))) + 0.5*vel(i+1)**2)
+      ! conserved quantities + physical flux at j-1, j, j+1 (shared EOS)
+      call prim_to_cons_flux(rho(i-1), vel(i-1), prs(i-1), W(1:3), flux(1:3))
+      call prim_to_cons_flux(rho(i),   vel(i),   prs(i),   W(4:6), flux(4:6))
+      call prim_to_cons_flux(rho(i+1), vel(i+1), prs(i+1), W(7:9), flux(7:9))
 
-
-      ! Fluxes 
-      ! j-1
-      eng = prs(i-1)/((gamma-1.0)*rho(i-1)) + 0.5*vel(i-1)**2
-      flux(1) = rho(i-1)*vel(i-1)
-      flux(2) = rho(i-1)*vel(i-1)**2 + prs(i-1)
-      flux(3) = vel(i-1)*(rho(i-1)*eng + prs(i-1))
-
-      ! now update the solution for location i-1
+      ! now update the solution for location i-1 (full-step result from the
+      ! previous iteration). Done after W(1:3)/flux(1:3) are read so the j-1
+      ! stencil still uses the pre-update primitives.
       if (i > 3) then
-        rho(i-1) = uve(1)
-        vel(i-1) = uve(2)/uve(1)
-        prs(i-1) = (gamma - 1.0)*uve(1)*((uve(3)/uve(1)) - 0.5*vel(i-1)**2)
+        call cons_to_prim(uve, rho(i-1), vel(i-1), prs(i-1))
         if(prs(i-1) < 0.0) then
           print*, "Ew...negative pressures being calculated."
         end if
-      end if 
-
-      ! j
-      eng = prs(i)/((gamma-1.0)*rho(i)) + 0.5*vel(i)**2
-      flux(4) = rho(i)*vel(i)
-      flux(5) = rho(i)*vel(i)**2 + prs(i)
-      flux(6) = vel(i)*(rho(i)*eng + prs(i))
-
-      !j+1
-      eng = prs(i+1)/((gamma-1.0)*rho(i+1)) + 0.5*vel(i+1)**2
-      flux(7) = rho(i+1)*vel(i+1)
-      flux(8) = rho(i+1)*vel(i+1)**2 + prs(i+1)
-      flux(9) = vel(i+1)*(rho(i+1)*eng + prs(i+1))
+      end if
 
       ! half time step
       uph = 0.5*(W(4:6) + W(7:9)) -   &
@@ -89,36 +63,22 @@ submodule (fluid_forge) lax_wendroff_impl
       umh = 0.5*(W(4:6) + W(1:3)) -   &
             dt/(2.0*dx)*(flux(4:6) - flux(1:3))
 
-      ! flux j + 1/2
-      uph(2) = uph(2)/uph(1)
-      uph(3) = uph(3)/uph(1)
-      prsh = (gamma - 1.0)*uph(1)*(uph(3) - 0.5*uph(2)**2)
-      flux(1) = uph(1)*uph(2)
-      flux(2) = uph(1)*uph(2)**2 + prsh
-      flux(3) = uph(2)*(uph(1)*uph(3) + prsh)
-      
-      ! flux j - 1/2
-      umh(2) = umh(2)/umh(1)
-      umh(3) = umh(3)/umh(1)
-      prsh = (gamma - 1.0)*umh(1)*(umh(3) - 0.5*umh(2)**2)
-      flux(4) = umh(1)*umh(2)
-      flux(5) = umh(1)*umh(2)**2 + prsh
-      flux(6) = umh(2)*(umh(1)*umh(3) + prsh)
+      ! physical flux at the half-step (conserved) states
+      fph = flux_from_cons(uph)
+      fmh = flux_from_cons(umh)
 
       ! Full time step
-      uve = W(4:6) - dt/dx*(flux(1:3) - flux(4:6))
+      uve = W(4:6) - dt/dx*(fph - fmh)
 
       ! update since this is last location to compute
       if (i==nx-2) then
-        rho(i) = uve(1)
-        vel(i) = uve(2)/uve(1)
-        prs(i) = (gamma - 1.0) * uve(1) * ((uve(3)/uve(1)) - 0.5*vel(i)**2)
+        call cons_to_prim(uve, rho(i), vel(i), prs(i))
         if(prs(i) < 0.0) then
           print*, "Ew...negative pressures being calculated."
         end if
       end if
 
-    end do    
+    end do
     
     ! boundary cells
     rho(1) = rho(3)

--- a/src/roe_solver.f90
+++ b/src/roe_solver.f90
@@ -1,5 +1,6 @@
 submodule (fluid_forge) roe_solver_impl
   use iso_fortran_env, only: real64, int32
+  use euler_core, only: prim_to_cons_flux, cons_to_prim, gamma => gamma_g
   implicit none
 
   contains
@@ -42,44 +43,20 @@ submodule (fluid_forge) roe_solver_impl
     !> @param [in]    dt     Time step size
     !> @param [in]    dx     Grid spacing
     module procedure roe
-      real(real64), parameter :: gamma = 1.4
       integer(int32) :: i
       real(real64) :: flux(9), w(9), diff(3), qnty(3), update(3), roe_flux(3, 2)
       real(real64) :: eigvec(3, 3), eigvecinv(3, 3), diag(3,3), roe_jac(3,3)
-      real(real64) :: dtdx, eng
+      real(real64) :: dtdx
       dtdx = dt/dx
 
       do i=3, nx-2
 
-        !fluxes
-        ! j-1
-        eng = prs(i-1)/((gamma-1.0)*rho(i-1)) + 0.5*vel(i-1)**2
-        flux(1) = rho(i-1)*vel(i-1)
-        flux(2) = rho(i-1)*vel(i-1)**2 + prs(i-1)
-        flux(3) = vel(i-1)*(rho(i-1)*eng + prs(i-1))
-        ! j
-        eng = prs(i)/((gamma-1.0)*rho(i)) + 0.5*vel(i)**2
-        flux(4) = rho(i)*vel(i)
-        flux(5) = rho(i)*vel(i)**2 + prs(i)
-        flux(6) = vel(i)*(rho(i)*eng + prs(i))
-        ! j+1
-        eng = prs(i+1)/((gamma-1.0)*rho(i+1)) + 0.5*vel(i+1)**2
-        flux(7) = rho(i+1)*vel(i+1)
-        flux(8) = rho(i+1)*vel(i+1)**2 + prs(i+1)
-        flux(9) = vel(i+1)*(rho(i+1)*eng + prs(i+1))
+        ! conserved variables (density, momentum, energy) + physical flux
+        ! at i-1, i, and i+1 (shared EOS from euler_core)
+        call prim_to_cons_flux(rho(i-1), vel(i-1), prs(i-1), w(1:3), flux(1:3))
+        call prim_to_cons_flux(rho(i),   vel(i),   prs(i),   w(4:6), flux(4:6))
+        call prim_to_cons_flux(rho(i+1), vel(i+1), prs(i+1), w(7:9), flux(7:9))
 
-        ! Store conserved variables (density, momentum, energy)
-        ! at i-1, i, and i+1
-        w(1) = rho(i-1)
-        w(2) = rho(i-1)*vel(i-1)
-        w(3) = rho(i-1)*((prs(i-1)/((gamma - 1.0)*rho(i-1))) + 0.5*vel(i-1)**2)
-        w(4) = rho(i)
-        w(5) = rho(i)*vel(i)
-        w(6) = rho(i)*((prs(i)/((gamma - 1.0)*rho(i))) + 0.5*vel(i)**2)
-        w(7) = rho(i+1)
-        w(8) = rho(i+1)*vel(i+1)
-        w(9) = rho(i+1)*((prs(i+1)/((gamma - 1.0)*rho(i+1))) + 0.5*vel(i+1)**2)
-        
         ! Compute Roe flux at i+1/2 interface
         call jac_decomp(rho, vel, prs, i-1, eigvec, eigvecinv, diag)
         roe_jac = matmul(eigvec, diag)
@@ -106,10 +83,8 @@ submodule (fluid_forge) roe_solver_impl
         w(4:6) = w(4:6) - dtdx*(roe_flux(:, 2) - roe_flux(:, 1))
 
         ! Update primitive variables from conserved variable
-        if (i > 3) then 
-          rho(i-1) = update(1)
-          vel(i-1) = update(2)/update(1)
-          prs(i-1) = (gamma - 1.0_real64)*update(1)*((update(3)/update(1)) - 0.5_real64*vel(i-1)**2)
+        if (i > 3) then
+          call cons_to_prim(update, rho(i-1), vel(i-1), prs(i-1))
           if(prs(i-1) < 0.0) then
             print*, "Ew...negative pressures being calculated."
           end if
@@ -118,10 +93,8 @@ submodule (fluid_forge) roe_solver_impl
         update = w(4:6)
 
         ! Update last point in loop
-        if (i == nx-2) then 
-          rho(i) = update(1)
-          vel(i) = update(2)/update(1)
-          prs(i) = (gamma - 1.0_real64)*update(1)*((update(3)/update(1)) - 0.5_real64*vel(i)**2)
+        if (i == nx-2) then
+          call cons_to_prim(update, rho(i), vel(i), prs(i))
           if(prs(i) < 0.0) then
             print*, "Ew...negative pressures being calculated."
           end if
@@ -184,7 +157,6 @@ submodule (fluid_forge) roe_solver_impl
       real(real64), intent(in) :: rho(:), vel(:), prs(:)
       integer(int32), intent(in) :: idx
       real(real64), intent(out) :: eigvec(3,3), eigvecinv(3,3), diag(3,3)
-      real(real64), parameter :: gamma = 1.4
       real(real64) :: rhoavg, velavg, enthalpy_avg, enthalpy(2), cs, &
                         denom, alpha
       

--- a/src/weno3_solver.f90
+++ b/src/weno3_solver.f90
@@ -1,8 +1,8 @@
 submodule (fluid_forge) weno3_impl
   use iso_fortran_env, only: real64, int32
+  use euler_core, only: prim_to_cons_flux, cons_to_prim, gamma_g
   implicit none
 
-  real(real64), parameter :: gamma_g  = 1.4_real64
   real(real64), parameter :: weno_eps = 1.0e-6_real64
 
   contains
@@ -64,28 +64,19 @@ submodule (fluid_forge) weno3_impl
   !> @param [in]    dx    Grid spacing
   module procedure weno3
     integer(int32) :: i, k
-    real(real64) :: dtdx, alpha
-    real(real64) :: u_loc, c_loc, p_loc, rho_loc
+    real(real64) :: dtdx, alpha, c_loc
     real(real64) :: u_cons(3, nx), f_phys(3, nx)
     real(real64) :: fp(3, nx), fm(3, nx)
     real(real64) :: f_face(3, nx)
 
     dtdx = dt / dx
 
-    ! Primitive -> conserved + physical flux + global max wave speed
+    ! Primitive -> conserved + physical flux (shared EOS) + global max wave speed
     alpha = 0.0_real64
     do i = 1, nx
-      rho_loc = rho(i)
-      u_loc   = vel(i)
-      p_loc   = prs(i)
-      u_cons(1, i) = rho_loc
-      u_cons(2, i) = rho_loc * u_loc
-      u_cons(3, i) = p_loc / (gamma_g - 1.0_real64) + 0.5_real64 * rho_loc * u_loc**2
-      c_loc = sqrt(gamma_g * p_loc / rho_loc)
-      f_phys(1, i) = u_cons(2, i)
-      f_phys(2, i) = u_cons(2, i) * u_loc + p_loc
-      f_phys(3, i) = u_loc * (u_cons(3, i) + p_loc)
-      alpha = max(alpha, abs(u_loc) + c_loc)
+      call prim_to_cons_flux(rho(i), vel(i), prs(i), u_cons(:, i), f_phys(:, i))
+      c_loc = sqrt(gamma_g * prs(i) / rho(i))
+      alpha = max(alpha, abs(vel(i)) + c_loc)
     end do
 
     ! Lax-Friedrichs flux splitting
@@ -114,9 +105,7 @@ submodule (fluid_forge) weno3_impl
       do k = 1, 3
         u_cons(k, i) = u_cons(k, i) - dtdx * (f_face(k, i) - f_face(k, i-1))
       end do
-      rho(i) = u_cons(1, i)
-      vel(i) = u_cons(2, i) / u_cons(1, i)
-      prs(i) = (gamma_g - 1.0_real64) * (u_cons(3, i) - 0.5_real64 * u_cons(2, i)**2 / u_cons(1, i))
+      call cons_to_prim(u_cons(:, i), rho(i), vel(i), prs(i))
       if (prs(i) < 0.0_real64) then
         print *, "Ew...negative pressures being calculated."
       end if

--- a/src/weno5_solver.f90
+++ b/src/weno5_solver.f90
@@ -1,8 +1,8 @@
 submodule (fluid_forge) weno5_impl
   use iso_fortran_env, only: real64, int32
+  use euler_core, only: prim_to_cons_flux, cons_to_prim, gamma_g
   implicit none
 
-  real(real64), parameter :: gamma_g  = 1.4_real64
   real(real64), parameter :: weno_eps = 1.0e-6_real64
 
   contains
@@ -59,27 +59,19 @@ submodule (fluid_forge) weno5_impl
   !> @param [in]    dx    Grid spacing
   module procedure weno5
     integer(int32) :: i, k
-    real(real64) :: dtdx, alpha
-    real(real64) :: u_loc, c_loc, p_loc, rho_loc
+    real(real64) :: dtdx, alpha, c_loc
     real(real64) :: u_cons(3, nx), f_phys(3, nx)
     real(real64) :: fp(3, nx), fm(3, nx)
     real(real64) :: f_face(3, nx)
 
     dtdx = dt / dx
 
+    ! Primitive -> conserved + physical flux (shared EOS) + global max wave speed
     alpha = 0.0_real64
     do i = 1, nx
-      rho_loc = rho(i)
-      u_loc   = vel(i)
-      p_loc   = prs(i)
-      u_cons(1, i) = rho_loc
-      u_cons(2, i) = rho_loc * u_loc
-      u_cons(3, i) = p_loc / (gamma_g - 1.0_real64) + 0.5_real64 * rho_loc * u_loc**2
-      c_loc = sqrt(gamma_g * p_loc / rho_loc)
-      f_phys(1, i) = u_cons(2, i)
-      f_phys(2, i) = u_cons(2, i) * u_loc + p_loc
-      f_phys(3, i) = u_loc * (u_cons(3, i) + p_loc)
-      alpha = max(alpha, abs(u_loc) + c_loc)
+      call prim_to_cons_flux(rho(i), vel(i), prs(i), u_cons(:, i), f_phys(:, i))
+      c_loc = sqrt(gamma_g * prs(i) / rho(i))
+      alpha = max(alpha, abs(vel(i)) + c_loc)
     end do
 
     ! Lax-Friedrichs flux splitting
@@ -107,9 +99,7 @@ submodule (fluid_forge) weno5_impl
       do k = 1, 3
         u_cons(k, i) = u_cons(k, i) - dtdx * (f_face(k, i) - f_face(k, i-1))
       end do
-      rho(i) = u_cons(1, i)
-      vel(i) = u_cons(2, i) / u_cons(1, i)
-      prs(i) = (gamma_g - 1.0_real64) * (u_cons(3, i) - 0.5_real64 * u_cons(2, i)**2 / u_cons(1, i))
+      call cons_to_prim(u_cons(:, i), rho(i), vel(i), prs(i))
       if (prs(i) < 0.0_real64) then
         print *, "Ew...negative pressures being calculated."
       end if

--- a/test/check.f90
+++ b/test/check.f90
@@ -1,5 +1,101 @@
 program check
-implicit none
+  !> Unit tests for euler_core, the shared 1D-Euler physics used by the
+  !> lax_wendroff, roe, weno3 and weno5 solvers. These exercise the
+  !> equation of state and flux routines directly so a regression in the
+  !> shared core is caught here rather than as a subtle drift in every
+  !> solver's CSV output.
+  use iso_fortran_env, only: real64, error_unit
+  use euler_core, only: gamma_g, prim_to_cons_flux, flux_from_cons, cons_to_prim
+  implicit none
 
-print *, "I might put some tests in here later!"
+  integer :: nfail = 0
+  real(real64), parameter :: tol = 1.0e-9_real64
+
+  call test_gamma()
+  call test_known_values()
+  call test_zero_velocity()
+  call test_prim_cons_roundtrip()
+  call test_flux_consistency()
+
+  if (nfail == 0) then
+    print *, "All euler_core tests passed."
+  else
+    write(error_unit, '(A,I0,A)') "FAILED: ", nfail, " euler_core check(s) failed."
+    error stop 1
+  end if
+
+contains
+
+  !> Compare two scalars with a mixed absolute/relative tolerance and
+  !> record a failure (without aborting) so every check in a test runs.
+  subroutine assert_close(got, want, name)
+    real(real64), intent(in) :: got, want
+    character(*), intent(in) :: name
+    if (abs(got - want) > tol * max(1.0_real64, abs(want))) then
+      write(error_unit, '(A,A,A,ES23.15,A,ES23.15)') &
+        "  FAIL ", name, ": got ", got, ", want ", want
+      nfail = nfail + 1
+    end if
+  end subroutine assert_close
+
+  !> The single canonical ratio of specific heats. The hand-computed
+  !> expected values below assume gamma = 1.4; this guards that premise.
+  subroutine test_gamma()
+    call assert_close(gamma_g, 1.4_real64, "gamma_g")
+  end subroutine test_gamma
+
+  !> Hand-computed conserved vector and physical flux for a known state.
+  !> rho=2, u=3, p=5, gamma=1.4:
+  !>   E       = p/(gamma-1) + 0.5*rho*u^2 = 12.5 + 9 = 21.5
+  !>   U       = (2, 6, 21.5)
+  !>   F(U)    = (rho*u, rho*u^2 + p, u*(E + p)) = (6, 23, 79.5)
+  subroutine test_known_values()
+    real(real64) :: u_cons(3), f_phys(3)
+    call prim_to_cons_flux(2.0_real64, 3.0_real64, 5.0_real64, u_cons, f_phys)
+    call assert_close(u_cons(1),  2.0_real64,  "known U(1)")
+    call assert_close(u_cons(2),  6.0_real64,  "known U(2)")
+    call assert_close(u_cons(3), 21.5_real64,  "known U(3)")
+    call assert_close(f_phys(1),  6.0_real64,  "known F(1)")
+    call assert_close(f_phys(2), 23.0_real64,  "known F(2)")
+    call assert_close(f_phys(3), 79.5_real64,  "known F(3)")
+  end subroutine test_known_values
+
+  !> At rest (u=0) the momentum flux is pure pressure and the mass and
+  !> energy fluxes vanish; internal energy is p/(gamma-1).
+  subroutine test_zero_velocity()
+    real(real64) :: u_cons(3), f_phys(3)
+    call prim_to_cons_flux(1.0_real64, 0.0_real64, 1.0_real64, u_cons, f_phys)
+    call assert_close(u_cons(2), 0.0_real64, "rest U(2)")
+    call assert_close(u_cons(3), 1.0_real64 / (gamma_g - 1.0_real64), "rest U(3)")
+    call assert_close(f_phys(1), 0.0_real64, "rest F(1)")
+    call assert_close(f_phys(2), 1.0_real64, "rest F(2)")
+    call assert_close(f_phys(3), 0.0_real64, "rest F(3)")
+  end subroutine test_zero_velocity
+
+  !> cons_to_prim must invert prim_to_cons_flux: primitives -> conserved
+  !> -> primitives recovers the original state. Uses a realistic
+  !> (non-trivial) state to exercise the energy/velocity round trip.
+  subroutine test_prim_cons_roundtrip()
+    real(real64), parameter :: rho0 = 1.225_real64, u0 = 37.0_real64, p0 = 101325.0_real64
+    real(real64) :: u_cons(3), f_phys(3), rho1, u1, p1
+    call prim_to_cons_flux(rho0, u0, p0, u_cons, f_phys)
+    call cons_to_prim(u_cons, rho1, u1, p1)
+    call assert_close(rho1, rho0, "roundtrip rho")
+    call assert_close(u1,   u0,   "roundtrip u")
+    call assert_close(p1,   p0,   "roundtrip p")
+  end subroutine test_prim_cons_roundtrip
+
+  !> flux_from_cons (flux from a conserved vector) must agree with the
+  !> f_phys that prim_to_cons_flux produces from the matching primitives.
+  !> This is the equivalence the Lax-Wendroff half-step relies on.
+  subroutine test_flux_consistency()
+    real(real64), parameter :: rho0 = 0.8_real64, u0 = -1.5_real64, p0 = 2.3_real64
+    real(real64) :: u_cons(3), f_phys(3), f_from_cons(3)
+    call prim_to_cons_flux(rho0, u0, p0, u_cons, f_phys)
+    f_from_cons = flux_from_cons(u_cons)
+    call assert_close(f_from_cons(1), f_phys(1), "flux consistency F(1)")
+    call assert_close(f_from_cons(2), f_phys(2), "flux consistency F(2)")
+    call assert_close(f_from_cons(3), f_phys(3), "flux consistency F(3)")
+  end subroutine test_flux_consistency
+
 end program check


### PR DESCRIPTION
Introduces euler_core, a shared module for the equation of state, conserved/primitive variable conversions, and physical flux computation. Previously each solver (Lax-Wendroff, Roe, WENO3, WENO5) duplicated this logic.

Changes:
- Added src/euler_core.f90 — prim_to_cons_flux, flux_from_cons, cons_to_prim, and gamma_g
- Refactored Lax-Wendroff, Roe, WENO3, and WENO5 solvers to use the shared module
- Added unit tests in test/check.f90 covering gamma, known states, zero velocity, roundtrip conversion, and flux consistency
- Updated README description